### PR TITLE
Add unit tests for UCI parser and game flow

### DIFF
--- a/ChessApp.sln
+++ b/ChessApp.sln
@@ -8,6 +8,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "Core\Core.csproj", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Interop", "Interop\Interop.csproj", "{51318257-C2FC-41EC-A955-A31F21E1B15A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Interop.Tests", "tests\Interop.Tests\Interop.Tests.csproj", "{CF3B6956-9EE5-4D05-998D-BED9FEBF0433}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core.Tests", "tests\Core.Tests\Core.Tests.csproj", "{B21A2BED-8F66-41E5-B750-701FF8A557D3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +30,14 @@ Global
 		{51318257-C2FC-41EC-A955-A31F21E1B15A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{51318257-C2FC-41EC-A955-A31F21E1B15A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51318257-C2FC-41EC-A955-A31F21E1B15A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {CF3B6956-9EE5-4D05-998D-BED9FEBF0433}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {CF3B6956-9EE5-4D05-998D-BED9FEBF0433}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {CF3B6956-9EE5-4D05-998D-BED9FEBF0433}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {CF3B6956-9EE5-4D05-998D-BED9FEBF0433}.Release|Any CPU.Build.0 = Release|Any CPU
+                {B21A2BED-8F66-41E5-B750-701FF8A557D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B21A2BED-8F66-41E5-B750-701FF8A557D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B21A2BED-8F66-41E5-B750-701FF8A557D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B21A2BED-8F66-41E5-B750-701FF8A557D3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Core.Tests/GameControllerTests.cs
+++ b/tests/Core.Tests/GameControllerTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using Xunit;
+using Core;
+
+namespace Core.Tests
+{
+    public class GameControllerTests
+    {
+        [Fact]
+        public void GameController_Should_LoadStartpos_FEN()
+        {
+            var gc = new GameController();
+            gc.NewGame();
+            Assert.Equal("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1", gc.Fen);
+        }
+
+        [Fact]
+        public void GameController_Should_ApplyLegalMove_AndRejectIllegal()
+        {
+            var gc = new GameController();
+            gc.NewGame();
+            Assert.True(gc.TryApplyUserMove("e2", "e4", null));
+            Assert.Equal("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR w - - 0 1", gc.Fen);
+            Assert.False(gc.TryApplyUserMove("e2", "e4", null));
+        }
+    }
+
+    public class PgnServiceTests
+    {
+        [Fact]
+        public void PgnService_Should_EmitMinimalGameHeader()
+        {
+            var path = Path.GetTempFileName();
+            try
+            {
+                PgnService.SavePgn(path, Array.Empty<string>());
+                var lines = File.ReadAllLines(path);
+                Assert.StartsWith("[Event \"Casual Game\"]", lines[0]);
+                Assert.Contains("[Result \"*\"]", lines);
+            }
+            finally
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+    }
+}

--- a/tests/Interop.Tests/Fixtures/info_cp_multipv.txt
+++ b/tests/Interop.Tests/Fixtures/info_cp_multipv.txt
@@ -1,0 +1,3 @@
+info depth 20 multipv 1 score cp 34 pv e2e4 e7e5 g1f3
+info depth 20 multipv 2 score cp -11 pv d2d4 d7d5 c2c4
+info depth 20 multipv 3 score cp 0 pv g1f3 g8f6

--- a/tests/Interop.Tests/Fixtures/info_mate_short.txt
+++ b/tests/Interop.Tests/Fixtures/info_mate_short.txt
@@ -1,0 +1,3 @@
+info depth 12 score mate 3 pv e7e8q
+info depth 8 score mate 1 pv g2g1q
+info depth 10 score mate -2 pv a7a8q

--- a/tests/Interop.Tests/Fixtures/info_perf_counters.txt
+++ b/tests/Interop.Tests/Fixtures/info_perf_counters.txt
@@ -1,0 +1,1 @@
+info depth 18 nodes 123456 nps 789012 tbhits 3 time 50 pv e2e4

--- a/tests/Interop.Tests/Fixtures/info_whitespace_variants.txt
+++ b/tests/Interop.Tests/Fixtures/info_whitespace_variants.txt
@@ -1,0 +1,3 @@
+info   depth 20    score cp 42   foo bar   pv e2e4 e7e5  
+info depth   15  score   mate  -1    pv a2a1q   
+info tbhits   7   nodes  100  unknown token pv d2d4   

--- a/tests/Interop.Tests/Interop.Tests.csproj
+++ b/tests/Interop.Tests/Interop.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Interop\Interop.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Fixtures\*.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/Interop.Tests/UciParserTests.cs
+++ b/tests/Interop.Tests/UciParserTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using Xunit;
+using Interop;
+
+namespace Interop.Tests
+{
+    static class Fixture
+    {
+        public static string[] ReadLines(string name)
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", name);
+            return File.ReadAllLines(path);
+        }
+    }
+
+    public class UciParserTests
+    {
+        [Fact]
+        public void UciParser_Should_ParseCentipawnAndMateScores()
+        {
+            var cpLine = Fixture.ReadLines("info_cp_multipv.txt")[0];
+            var cp = UciParser.TryParseInfo(cpLine)!;
+            Assert.False(cp.ScoreMate);
+            Assert.Equal(34, cp.ScoreCp);
+
+            var mateLines = Fixture.ReadLines("info_mate_short.txt");
+            var matePlus = UciParser.TryParseInfo(mateLines[0])!;
+            Assert.True(matePlus.ScoreMate);
+            Assert.Equal(3, matePlus.ScoreCp);
+            var mateNeg = UciParser.TryParseInfo(mateLines[2])!;
+            Assert.True(mateNeg.ScoreMate);
+            Assert.Equal(-2, mateNeg.ScoreCp);
+        }
+
+        [Fact]
+        public void UciParser_Should_ParseMultiPV_And_PVs()
+        {
+            var lines = Fixture.ReadLines("info_cp_multipv.txt");
+            var u1 = UciParser.TryParseInfo(lines[0])!;
+            Assert.Equal(1, u1.MultiPv);
+            Assert.Equal("e2e4 e7e5 g1f3", u1.Pv);
+            var u2 = UciParser.TryParseInfo(lines[1])!;
+            Assert.Equal(2, u2.MultiPv);
+            Assert.Equal("d2d4 d7d5 c2c4", u2.Pv);
+            var u3 = UciParser.TryParseInfo(lines[2])!;
+            Assert.Equal(3, u3.MultiPv);
+            Assert.Equal("g1f3 g8f6", u3.Pv);
+        }
+
+        [Fact]
+        public void UciParser_Should_HandleWhitespace_And_UnknownTokens()
+        {
+            var lines = Fixture.ReadLines("info_whitespace_variants.txt");
+            var u1 = UciParser.TryParseInfo(lines[0])!;
+            Assert.Equal(20, u1.Depth);
+            Assert.Equal(42, u1.ScoreCp);
+            Assert.Equal("e2e4 e7e5", u1.Pv);
+
+            var u2 = UciParser.TryParseInfo(lines[1])!;
+            Assert.True(u2.ScoreMate);
+            Assert.Equal(-1, u2.ScoreCp);
+
+            var u3 = UciParser.TryParseInfo(lines[2])!;
+            Assert.Equal(7, u3.TbHits);
+            Assert.Equal(100, u3.Nodes);
+            Assert.Equal("d2d4", u3.Pv);
+        }
+
+        [Fact]
+        public void UciParser_Should_ParsePerformanceCounters()
+        {
+            var line = Fixture.ReadLines("info_perf_counters.txt")[0];
+            var upd = UciParser.TryParseInfo(line)!;
+            Assert.Equal(123456, upd.Nodes);
+            Assert.Equal(789012, upd.Nps);
+            Assert.Equal(3, upd.TbHits);
+            Assert.Equal(50, upd.TimeMs);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add fixtures and xUnit tests for UCI info parsing
- cover GameController start position, move legality, and PGN header
- include new test projects in solution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2066f01bc832585dade0edc319a31