### PR TITLE
chore: add tag-based release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release
+      - name: Prepare package
+        shell: pwsh
+        run: ./Scripts/release-pack.ps1
+      - name: Create archive
+        shell: pwsh
+        run: |
+          $tag = $env:GITHUB_REF_NAME
+          $zipPath = "Artifacts/Chessapp-$tag-win64.zip"
+          Compress-Archive -Path "Artifacts/release/*" -DestinationPath $zipPath
+          echo "ZIP_PATH=$zipPath" >> $env:GITHUB_ENV
+      - name: Publish Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Chessapp ${{ github.ref_name }}
+          files: ${{ env.ZIP_PATH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,19 @@
+# Releasing Chessapp
+
+This project uses tag-driven releases. Creating an annotated tag that matches `v*` triggers
+an automated workflow on GitHub Actions which builds the application, packages the
+Windows binaries, and publishes a GitHub Release with the zip attached.
+
+## Cutting a release
+
+1. Ensure the `main` branch is up to date and all changes are committed.
+2. Choose the next semantic version. Versions follow the form `vMAJOR.MINOR.PATCH`.
+3. Create an annotated tag and push it:
+   ```bash
+   git tag -a vX.Y.Z -m "Chessapp vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+4. GitHub Actions builds the solution and uploads an artifact named
+   `Chessapp-vX.Y.Z-win64.zip` to a new GitHub Release titled `Chessapp vX.Y.Z`.
+
+No signing or MSIX packaging is performed. Releases currently target Windows x64 only.

--- a/Scripts/release-pack.ps1
+++ b/Scripts/release-pack.ps1
@@ -1,0 +1,14 @@
+Param()
+
+$root = Join-Path $PSScriptRoot ".."
+$buildDir = Join-Path $root "Gui\bin\Release\net8.0-windows"
+$dest = Join-Path $root "Artifacts\release"
+
+if (Test-Path $dest) {
+    Remove-Item $dest -Recurse -Force
+}
+New-Item -ItemType Directory -Path $dest | Out-Null
+
+Copy-Item -Path (Join-Path $buildDir "*") -Destination $dest -Recurse
+
+Write-Host "Release files staged at $dest"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and publish releases on tags
- stage built binaries with a PowerShell script
- document how to cut a release

## Testing
- ⚠️ `dotnet build ChessApp.sln --configuration Release` (missing `dotnet`)
- ⚠️ `pwsh Scripts/release-pack.ps1` (missing `pwsh`)


------
https://chatgpt.com/codex/tasks/task_e_68b2067ade9c8325a511bec44294d414