### PR TITLE
fix: harden smoke-uci script

### DIFF
--- a/Scripts/smoke-uci.ps1
+++ b/Scripts/smoke-uci.ps1
@@ -1,12 +1,12 @@
 $ErrorActionPreference = 'Stop'
 
-# Resolve repo root and engine path without using pipeline into Join-Path (PS on runners may not bind it)
-$root   = Join-Path -Path $PSScriptRoot -ChildPath '..'
-$engine = Join-Path -Path $root        -ChildPath 'Engines\stockfish.exe'
+# Resolve repo root and engine path without piping into Join-Path
+$root = Split-Path -Parent $PSScriptRoot
+$engine = Join-Path $root 'Engines/stockfish.exe'
 
 if (Test-Path -LiteralPath $engine) {
     Write-Host 'Engine found, performing handshake...'
-    $p = Start-Process -FilePath $engine -NoNewWindow -RedirectStandardInput StandardInput -RedirectStandardOutput StandardOutput -PassThru
+    $p = Start-Process -FilePath $engine -NoNewWindow -RedirectStandardInput 'Pipe' -RedirectStandardOutput 'Pipe' -PassThru
     try {
         $p.StandardInput.WriteLine('uci')
         Start-Sleep -Milliseconds 200


### PR DESCRIPTION
## Summary
- fix join-path usage in smoke-uci.ps1
- redirect I/O via pipes when starting Stockfish

## Testing
- `pwsh -NoLogo -File Scripts/smoke-uci.ps1` *(fails: command not found)*
- `dotnet test tests/Interop.Tests/Interop.Tests.csproj --nologo --filter "UciParser_Fixtures_Should_ParseKnownLines"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b21cd982388325a6b4ea88c8a59ce8