### PR TITLE
docs: add contributing guide and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: Bug report
+description: File a reproducible bug report.
+title: "[Bug]: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below.
+  - type: input
+    id: version
+    attributes:
+      label: App version
+      placeholder: v1.2.3
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the issue and what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: OS, .NET version
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log output
+      render: shell
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest an idea for ChessApp.
+title: "[Feature]: "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please answer the questions below.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem would this feature solve?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe your ideal solution.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+Describe the change and why it's needed.
+
+## Testing
+- [ ] `dotnet test`
+- [ ] `dotnet run --project Gui` (smoke test)
+
+## Acceptance Criteria
+- [ ] Follows [CONTRIBUTING](../CONTRIBUTING.md)
+- [ ] Uses Conventional Commits
+- [ ] Updates documentation if needed
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to ChessApp
+
+Thanks for your interest in improving ChessApp! This guide explains how to work with the repository and submit changes.
+
+## Tooling
+- [ .NET 8 SDK](https://dotnet.microsoft.com/) (required)
+- Windows 10/11 or recent Linux/macOS for development
+- Optional: Visual Studio 2022, Rider, or VS Code
+
+## Branch and PR model
+1. Create a topic branch from `main`.
+2. Keep commits focused; use [Conventional Commits](https://www.conventionalcommits.org/):
+   - `feat:` new feature
+   - `fix:` bug fix
+   - `docs:` documentation only
+   - `chore:` tooling or maintenance
+3. Push the branch and open a Pull Request.
+4. Run tests and a GUI smoke test before requesting review.
+
+## Code style
+- C# projects follow the default `.NET` conventions.
+- Run `dotnet format` to apply consistent styling.
+
+## Testing
+Run the full test suite from the repo root:
+```bash
+dotnet test
+```
+
+## Smoke test
+Verify that the GUI launches:
+```bash
+dotnet run --project Gui
+```
+
+## Need help?
+Open an issue using the templates in `.github/ISSUE_TEMPLATE` or start a discussion in the PR.
+


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guide outlining tooling, workflow and testing
- add issue templates for bugs and features
- add PR template with testing and acceptance criteria checklists

## Testing
- `dotnet test` *(fails: command not found)*
- `dotnet run --project Gui` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b21ee324ac8325b18a47328e868a18