### PR TITLE
Add UCI parser fixtures and tests for info and bestmove lines

### DIFF
--- a/Interop/UciParser.cs
+++ b/Interop/UciParser.cs
@@ -11,10 +11,17 @@ namespace Interop
         public int Nodes { get; set; }
         public int Nps { get; set; }
         public int TbHits { get; set; }
+        public int HashFull { get; set; }
         public string Pv { get; set; } = string.Empty;
         public string RootMove { get; set; } = string.Empty;
         public int MultiPv { get; set; } = 1;
         public int TimeMs { get; set; }
+    }
+
+    public class BestMove
+    {
+        public string Move { get; set; } = string.Empty;
+        public string Ponder { get; set; } = string.Empty;
     }
 
     public static class UciParser
@@ -32,6 +39,7 @@ namespace Interop
                 else if (t == "nodes" && i+1 < parts.Length && int.TryParse(parts[i+1], out var n)) { upd.Nodes = n; i++; }
                 else if (t == "nps" && i+1 < parts.Length && int.TryParse(parts[i+1], out var nps)) { upd.Nps = nps; i++; }
                 else if (t == "tbhits" && i+1 < parts.Length && int.TryParse(parts[i+1], out var tb)) { upd.TbHits = tb; i++; }
+                else if (t == "hashfull" && i+1 < parts.Length && int.TryParse(parts[i+1], out var hf)) { upd.HashFull = hf; i++; }
                 else if (t == "multipv" && i+1 < parts.Length && int.TryParse(parts[i+1], out var mpv)) { upd.MultiPv = mpv; i++; }
                 else if (t == "time" && i+1 < parts.Length && int.TryParse(parts[i+1], out var tm)) { upd.TimeMs = tm; i++; }
                 else if (t == "score" && i+1 < parts.Length)
@@ -48,6 +56,23 @@ namespace Interop
                 }
             }
             return upd;
+        }
+
+        public static BestMove? TryParseBestMove(string line)
+        {
+            if (string.IsNullOrWhiteSpace(line) || !line.StartsWith("bestmove ")) return null;
+            var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 2) return null;
+            var bm = new BestMove { Move = parts[1] };
+            for (int i = 2; i < parts.Length - 1; i++)
+            {
+                if (parts[i] == "ponder")
+                {
+                    bm.Ponder = parts[i + 1];
+                    break;
+                }
+            }
+            return bm;
         }
     }
 }

--- a/tests/Interop.Tests/Fixtures/bestmove.txt
+++ b/tests/Interop.Tests/Fixtures/bestmove.txt
@@ -1,0 +1,2 @@
+bestmove e2e4
+bestmove g1f3 ponder e7e5

--- a/tests/Interop.Tests/Fixtures/info_hashfull.txt
+++ b/tests/Interop.Tests/Fixtures/info_hashfull.txt
@@ -1,0 +1,2 @@
+info depth 25 seldepth 32 score cp 13 nodes 123456 nps 765432 hashfull 512 multipv 2 pv e2e4 e7e5 g1f3
+info depth 15 seldepth 22 score mate -3 nodes 2048 nps 8192 hashfull 873 multipv 1 pv d2d4 d7d5

--- a/tests/Interop.Tests/UciParser_Fixtures.cs
+++ b/tests/Interop.Tests/UciParser_Fixtures.cs
@@ -1,0 +1,58 @@
+using System.IO;
+using System.Reflection;
+using Interop;
+using Xunit;
+
+namespace Interop.Tests;
+
+public class UciParser_Fixtures
+{
+    private static string Fixture(string name)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        var dir = Path.Combine(Path.GetDirectoryName(asm.Location)!, "Fixtures");
+        return Path.Combine(dir, name);
+    }
+
+    [Fact]
+    public void Info_Should_Parse_All_Common_Fields()
+    {
+        var lines = File.ReadAllLines(Fixture("info_hashfull.txt"));
+        var upd = UciParser.TryParseInfo(lines[0])!;
+        Assert.Equal(25, upd.Depth);
+        Assert.Equal(32, upd.SelDepth);
+        Assert.Equal(13, upd.ScoreCp);
+        Assert.False(upd.ScoreMate);
+        Assert.Equal(123456, upd.Nodes);
+        Assert.Equal(765432, upd.Nps);
+        Assert.Equal(512, upd.HashFull);
+        Assert.Equal(2, upd.MultiPv);
+        Assert.Equal("e2e4", upd.RootMove);
+        Assert.Equal("e2e4 e7e5 g1f3", upd.Pv);
+
+        var upd2 = UciParser.TryParseInfo(lines[1])!;
+        Assert.Equal(15, upd2.Depth);
+        Assert.Equal(22, upd2.SelDepth);
+        Assert.Equal(-3, upd2.ScoreCp);
+        Assert.True(upd2.ScoreMate);
+        Assert.Equal(2048, upd2.Nodes);
+        Assert.Equal(8192, upd2.Nps);
+        Assert.Equal(873, upd2.HashFull);
+        Assert.Equal(1, upd2.MultiPv);
+        Assert.Equal("d2d4", upd2.RootMove);
+        Assert.Equal("d2d4 d7d5", upd2.Pv);
+    }
+
+    [Fact]
+    public void BestMove_Should_Parse_Move_And_Ponder()
+    {
+        var lines = File.ReadAllLines(Fixture("bestmove.txt"));
+        var bm1 = UciParser.TryParseBestMove(lines[0])!;
+        Assert.Equal("e2e4", bm1.Move);
+        Assert.Equal(string.Empty, bm1.Ponder);
+
+        var bm2 = UciParser.TryParseBestMove(lines[1])!;
+        Assert.Equal("g1f3", bm2.Move);
+        Assert.Equal("e7e5", bm2.Ponder);
+    }
+}


### PR DESCRIPTION
## Summary
- expand UCI parser to expose hashfull and bestmove information
- add fixtures covering multipv, pv, nodes, nps, hashfull and bestmove lines
- add tests validating parsing of info and bestmove fields

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b224fd9cec8325b9ef7870fa97fa3d