### PR TITLE
Fix Gui project SDK for .NET 8 WPF

### DIFF
--- a/Gui/Gui.csproj
+++ b/Gui/Gui.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />


### PR DESCRIPTION
## Summary
- use Microsoft.NET.Sdk.WindowsDesktop for Gui project
- enable implicit usings for Gui project

## Testing
- `dotnet build -c Release` *(failed: command not found)*
- `apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b22529e1608325932a213dbe1afe91