### PR TITLE
chore: normalize Scripts path casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [BUILD.md](docs/BUILD.md) for detailed instructions and [PROFILES.md](docs/P
 Run the PowerShell script to produce an MSIX package:
 
 ```powershell
-Scripts\build-msix.ps1
+Scripts/build-msix.ps1
 ```
 
 The packaged artifacts are written to the `artifacts` folder.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -17,7 +17,7 @@
 Furnizează certificatul PFX ca secret de repo (`SIGNING_CERT` în base64) și parola (`SIGNING_PASS`). Decodează în CI și rulează `signtool`:
 
 ```powershell
-# scripts/sign-msix.ps1
+# Scripts/sign-msix.ps1
 $certPath = "$env:RUNNER_TEMP\cert.pfx"
 [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($env:SIGNING_CERT))
 signtool sign /fd SHA256 /a /f $certPath /p $env:SIGNING_PASS out/installer/Chessapp.msix


### PR DESCRIPTION
## Summary
- ensure docs use canonical `Scripts/` directory
- standardize packaging instructions to reference `Scripts/sign-msix.ps1`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b225308eb48325a500aef1ea8f86db