### PR TITLE
Improve EngineHost lifecycle handling

### DIFF
--- a/Interop/EngineHost.cs
+++ b/Interop/EngineHost.cs
@@ -7,11 +7,18 @@ using System.Threading.Tasks;
 
 namespace Interop
 {
-    public class EngineHost : IDisposable
+    /// <summary>
+    /// Hosts a UCI engine process and provides async send/receive primitives.
+    /// Lifecycle is fully cancellable and deterministically disposed.
+    /// </summary>
+    public class EngineHost : IDisposable, IAsyncDisposable
     {
         private Process? _proc;
         private readonly BlockingCollection<string> _outgoing = new();
         private CancellationTokenSource? _cts;
+        private Task? _writerTask;
+        private Task? _readerTask;
+
         public bool IsRunning => _proc != null && !_proc.HasExited;
 
         public event Action? EngineReady;
@@ -19,6 +26,7 @@ namespace Interop
         public event Action<string>? BestMoveReceived;
         public event Action<Exception>? EngineCrashed;
 
+        /// <summary>Starts the engine process.</summary>
         public void Start(string enginePath)
         {
             Stop();
@@ -35,12 +43,12 @@ namespace Interop
                     CreateNoWindow = true,
                     WorkingDirectory = Path.GetDirectoryName(enginePath) ?? Environment.CurrentDirectory
                 },
-                EnableRaisingEvents = true
+                EnableRaisingEvents = true,
             };
             _proc.Exited += (_, __) => EngineCrashed?.Invoke(new Exception("Engine process exited."));
             _proc.Start();
-            Task.Run(() => WriterLoop(_cts.Token));
-            Task.Run(() => ReaderLoop(_cts.Token));
+            _writerTask = Task.Run(() => WriterLoop(_cts.Token));
+            _readerTask = Task.Run(() => ReaderLoop(_cts.Token));
         }
 
         public async Task SendAsync(string command)
@@ -50,21 +58,39 @@ namespace Interop
             await Task.CompletedTask;
         }
 
-        public async Task ExpectAsync(string token, TimeSpan timeout)
+        /// <summary>Waits until a line containing <paramref name="token"/> appears.</summary>
+        public async Task ExpectAsync(string token, TimeSpan timeout, CancellationToken cancellationToken = default)
         {
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             void handler(string line)
             {
-                if (line.IndexOf(token, StringComparison.OrdinalIgnoreCase) >= 0) tcs.TrySetResult(true);
+                if (line.IndexOf(token, StringComparison.OrdinalIgnoreCase) >= 0) tcs.TrySetResult();
             }
+
             InfoReceived += handler;
             try
             {
-                using var cts = new CancellationTokenSource(timeout);
-                await Task.WhenAny(tcs.Task, Task.Delay(Timeout.InfiniteTimeSpan, cts.Token));
-                if (!tcs.Task.IsCompleted) throw new TimeoutException($"Timeout waiting for '{token}'");
+                using var timeoutCts = new CancellationTokenSource(timeout);
+                using var linked = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
+                await tcs.Task.WaitAsync(linked.Token);
             }
-            finally { InfoReceived -= handler; }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException($"Timeout waiting for '{token}'");
+            }
+            finally
+            {
+                InfoReceived -= handler;
+            }
+        }
+
+        /// <summary>
+        /// Sends the <c>uci</c> command and awaits the <c>uciok</c> response.
+        /// </summary>
+        public async Task UciHandshakeAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            await SendAsync("uci");
+            await ExpectAsync("uciok", timeout, cancellationToken);
         }
 
         private async Task WriterLoop(CancellationToken ct)
@@ -88,7 +114,7 @@ namespace Interop
             {
                 while (!ct.IsCancellationRequested && IsRunning && !_proc!.StandardOutput.EndOfStream)
                 {
-                    string? line = await _proc!.StandardOutput.ReadLineAsync();
+                    string? line = await _proc!.StandardOutput.ReadLineAsync(ct);
                     if (line is null) break;
                     if (line.StartsWith("info ")) InfoReceived?.Invoke(line);
                     else if (line.StartsWith("bestmove "))
@@ -103,22 +129,43 @@ namespace Interop
                     }
                 }
             }
+            catch (OperationCanceledException) { }
             catch (Exception ex) { EngineCrashed?.Invoke(ex); }
         }
 
-        public void Stop()
+        public void Stop() => StopAsync().GetAwaiter().GetResult();
+
+        public async Task StopAsync(CancellationToken cancellationToken = default)
         {
             try
             {
                 _cts?.Cancel();
+
                 if (_proc != null && !_proc.HasExited)
                 {
-                    try { _proc.StandardInput.WriteLine("quit"); } catch { }
-                    _proc.Kill(entireProcessTree: true);
+                    try { await _proc.StandardInput.WriteLineAsync("quit"); } catch { }
+
+                    using var exitCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    exitCts.CancelAfter(TimeSpan.FromSeconds(1));
+                    try { await _proc.WaitForExitAsync(exitCts.Token); }
+                    catch (OperationCanceledException)
+                    {
+                        if (!_proc.HasExited) _proc.Kill(entireProcessTree: true);
+                    }
                 }
+
+                if (_writerTask != null) await _writerTask.ConfigureAwait(false);
+                if (_readerTask != null) await _readerTask.ConfigureAwait(false);
             }
             catch { }
-            finally { _proc?.Dispose(); _proc = null; }
+            finally
+            {
+                _proc?.Dispose();
+                _proc = null;
+                _cts?.Dispose();
+                _cts = null;
+                _writerTask = _readerTask = null;
+            }
         }
 
         public async Task ApplyCommonOptionsAsync(Core.AppSettings cfg)
@@ -127,10 +174,22 @@ namespace Interop
             if (cfg.Threads > 0) await SendAsync($"setoption name Threads value {cfg.Threads}");
             if (cfg.Hash > 0) await SendAsync($"setoption name Hash value {cfg.Hash}");
             await SendAsync($"setoption name Ponder value {(cfg.Ponder ? "true" : "false")}");
-            if (!string.IsNullOrWhiteSpace(cfg.SyzygyPath)) await SendAsync($"setoption name SyzygyPath value {cfg.SyzygyPath}");
+            if (!string.IsNullOrWhiteSpace(cfg.SyzygyPath))
+                await SendAsync($"setoption name SyzygyPath value {cfg.SyzygyPath}");
             await SendAsync($"setoption name MultiPV value {cfg.MultiPV}");
         }
 
-        public void Dispose() => Stop();
+        public void Dispose()
+        {
+            Stop();
+            GC.SuppressFinalize(this);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await StopAsync();
+            GC.SuppressFinalize(this);
+        }
     }
 }
+

--- a/tests/Interop.Tests/EngineHostTests.cs
+++ b/tests/Interop.Tests/EngineHostTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Interop;
+using Xunit;
+
+namespace Interop.Tests
+{
+    public class EngineHostTests
+    {
+        [Fact]
+        public async Task StartHandshakeAndDisposeStopsProcess()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                // scripting via bash is unavailable; skip on Windows.
+                return;
+            }
+
+            var script = "#!/usr/bin/env bash\n" +
+                         "while read line; do\n" +
+                         "  if [[ \"$line\" == \"uci\" ]]; then echo uciok; fi\n" +
+                         "  if [[ \"$line\" == \"quit\" ]]; then break; fi\n" +
+                         "done\n";
+
+            var path = Path.Combine(Path.GetTempPath(), $"fake_engine_{Guid.NewGuid():N}.sh");
+            await File.WriteAllTextAsync(path, script);
+            Process.Start("chmod", $"+x {path}")!.WaitForExit();
+
+            await using var host = new EngineHost();
+            host.Start(path);
+            await host.UciHandshakeAsync(TimeSpan.FromSeconds(1));
+
+            await host.DisposeAsync();
+            Assert.False(host.IsRunning);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make EngineHost cancellable and implement IDisposable/IAsyncDisposable
- add UCI handshake helper with timeout
- cover EngineHost start/stop semantics with unit test

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68b224f837d4832595bd6083dafa93bc