### PR TITLE
feat(core): add engine move API

### DIFF
--- a/Core/GameController.cs
+++ b/Core/GameController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Core;
@@ -15,6 +16,9 @@ public class GameController
 
     // Very small move list so the GUI can build a UCI "position" command.
     private readonly List<string> _moves = new();
+
+    /// <summary>Raised whenever an engine move is applied.</summary>
+    public event Action<string>? EngineMoveApplied;
 
     /// <summary>Resets to the initial chess position.</summary>
     public void NewGame()
@@ -59,16 +63,24 @@ public class GameController
         => TryApplyUserMove(BuildUci(from, to, promotion));
 
     /// <summary>
-    /// Applies an engine move in UCI form. Returns true if recorded.
+    /// Applies an engine move in UCI form. Uses the same validation as user
+    /// moves and updates the internal move list. Raises <see
+    /// cref="EngineMoveApplied"/> when successful.
     /// </summary>
-    public bool ApplyEngineMove(string uci) => TryApplyUserMove(uci);
+    public void ApplyEngineMove(string uci)
+    {
+        if (TryApplyUserMove(uci))
+        {
+            EngineMoveApplied?.Invoke(uci.Trim());
+        }
+    }
 
     /// <summary>
-    /// Overload for engine move using separate components (from, to, promotion).
-    /// Returns true if recorded.
+    /// Overload for engine move using separate components (from, to,
+    /// promotion).
     /// </summary>
-    public bool ApplyEngineMove(object from, object to, object? promotion = null)
-        => TryApplyUserMove(BuildUci(from, to, promotion));
+    public void ApplyEngineMove(object from, object to, object? promotion = null)
+        => ApplyEngineMove(BuildUci(from, to, promotion));
 
     // Helpers
     private static string BuildUci(object from, object to, object? promotion)

--- a/tests/Core.Tests/GameControllerTests.cs
+++ b/tests/Core.Tests/GameControllerTests.cs
@@ -30,4 +30,24 @@ public class GameControllerTests
         gc.TryApplyUserMove("c7c5");
         Assert.Equal("position startpos moves e2e4 c7c5", gc.ToUciPositionCommand());
     }
+
+    [Fact]
+    public void ApplyEngineMove_Should_RecordMove()
+    {
+        var gc = new GameController();
+        gc.NewGame();
+        gc.ApplyEngineMove("g8f6");
+        Assert.Equal("position startpos moves g8f6", gc.ToUciPositionCommand());
+    }
+
+    [Fact]
+    public void ApplyEngineMove_Should_RaiseEvent()
+    {
+        var gc = new GameController();
+        gc.NewGame();
+        string? notified = null;
+        gc.EngineMoveApplied += m => notified = m;
+        gc.ApplyEngineMove("g8f6");
+        Assert.Equal("g8f6", notified);
+    }
 }


### PR DESCRIPTION
## Summary
- expose `ApplyEngineMove` method that records engine moves and raises an event
- cover engine move application with unit tests

## Testing
- `dotnet test tests/Core.Tests/Core.Tests.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b226ec80188325af56707688062ae7