### PR TITLE
fix: align GUI namespace imports

### DIFF
--- a/Gui/InsightsView.xaml.cs
+++ b/Gui/InsightsView.xaml.cs
@@ -1,7 +1,7 @@
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using Core;
+using Chessapp.Core;
 
 namespace Gui
 {

--- a/Gui/MainWindow.xaml.cs
+++ b/Gui/MainWindow.xaml.cs
@@ -3,8 +3,8 @@ using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.Win32;
-using Core;
-using Interop;
+using Chessapp.Core;
+using Chessapp.Interop;
 
 namespace Gui
 {


### PR DESCRIPTION
## Summary
- ensure GUI uses Chessapp.Core and Chessapp.Interop namespaces

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b22ad159ac83259af95c054b1dfa3e