### PR TITLE
Show analysis summary above board

### DIFF
--- a/Gui/MainWindow.xaml
+++ b/Gui/MainWindow.xaml
@@ -31,6 +31,13 @@
       </TabControl>
     </StackPanel>
 
-    <controls:BoardControl x:Name="Board" Grid.Column="1" Margin="8"/>
+    <Grid Grid.Column="1" Margin="8">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="*"/>
+      </Grid.RowDefinitions>
+      <TextBlock Text="{Binding AnalysisHeader}" Margin="0,0,0,8" FontWeight="Bold"/>
+      <controls:BoardControl x:Name="Board" Grid.Row="1"/>
+    </Grid>
   </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- Display latest engine analysis above board via new bound TextBlock
- Track engine depth, eval and first four PV moves in `AnalysisHeader` property
- Reset header to `Engine idle` when engine stops

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b22f63c794832598d6e7ad9af1bed9