### PR TITLE
Add engine path and depth settings

### DIFF
--- a/Core/ConfigService.cs
+++ b/Core/ConfigService.cs
@@ -8,6 +8,7 @@ namespace Core
     public class AppSettings
     {
         public string EnginePath { get; set; } = "Engines/stockfish.exe";
+        public int Depth { get; set; } = 20;
         public int Threads { get; set; } = Environment.ProcessorCount - 1 > 0 ? Environment.ProcessorCount - 1 : 1;
         public int Hash { get; set; } = 1024;
         public bool Ponder { get; set; } = true;

--- a/Data/appsettings.json
+++ b/Data/appsettings.json
@@ -1,5 +1,6 @@
 {
   "EnginePath": "Engines/stockfish.exe",
+  "Depth": 20,
   "Threads": 8,
   "Hash": 1024,
   "Ponder": true,

--- a/Gui/MainWindow.xaml
+++ b/Gui/MainWindow.xaml
@@ -18,7 +18,7 @@
       </StackPanel>
       <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
         <Button Name="BtnStop" Content="Stop" Width="120" Margin="0,0,8,0" Click="BtnStop_Click"/>
-        <Button Name="BtnLoadEngine" Content="Engine..." Width="120" Click="BtnLoadEngine_Click"/>
+        <Button Name="BtnSettings" Content="Settings..." Width="120" Click="BtnSettings_Click"/>
       </StackPanel>
       <TextBlock Name="TxtPv" Margin="0,0,0,8" TextWrapping="Wrap"/>
       <TabControl Height="420" Margin="0,8,0,0">

--- a/Gui/MainWindow.xaml.cs
+++ b/Gui/MainWindow.xaml.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
-using Microsoft.Win32;
 using Chessapp.Core;
 using Chessapp.Interop;
 
@@ -141,7 +140,7 @@ namespace Gui
             await _engine.ApplyCommonOptionsAsync(cfg);
             await _engine.SendAsync(_game.ToUciPositionCommand());
             await _engine.SendAsync("setoption name MultiPV value 3");
-            await _engine.SendAsync("go infinite");
+            await _engine.SendAsync($"go depth {cfg.Depth}");
         }
 
         private async void BtnStop_Click(object sender, RoutedEventArgs e)
@@ -153,15 +152,13 @@ namespace Gui
             _analyzing = false;
         }
 
-        private void BtnLoadEngine_Click(object sender, RoutedEventArgs e)
+        private void BtnSettings_Click(object sender, RoutedEventArgs e)
         {
-            var ofd = new OpenFileDialog { Filter = "Engine (*.exe)|*.exe" };
-            if (ofd.ShowDialog() == true)
+            var dlg = new SettingsWindow();
+            if (dlg.ShowDialog() == true)
             {
-                _enginePath = ofd.FileName;
                 var cfg = ConfigService.LoadAppSettings();
-                cfg.EnginePath = _enginePath;
-                ConfigService.SaveAppSettings(cfg);
+                _enginePath = cfg.EnginePath;
                 AppendInfo($"Engine set: {_enginePath}");
             }
         }

--- a/Gui/SettingsWindow.xaml
+++ b/Gui/SettingsWindow.xaml
@@ -1,0 +1,18 @@
+<Window x:Class="Gui.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Settings" WindowStartupLocation="CenterOwner" SizeToContent="WidthAndHeight">
+  <StackPanel Margin="10">
+    <TextBlock Text="Engine path"/>
+    <StackPanel Orientation="Horizontal" Margin="0,5,0,10">
+      <TextBox x:Name="TxtEnginePath" Width="250"/>
+      <Button Content="Browse..." Margin="5,0,0,0" Click="Browse_Click"/>
+    </StackPanel>
+    <TextBlock Text="Analysis depth"/>
+    <TextBox x:Name="TxtDepth" Width="60" Margin="0,5,0,10"/>
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+      <Button Content="OK" Width="75" Margin="0,0,5,0" Click="Ok_Click"/>
+      <Button Content="Cancel" Width="75" Click="Cancel_Click"/>
+    </StackPanel>
+  </StackPanel>
+</Window>

--- a/Gui/SettingsWindow.xaml.cs
+++ b/Gui/SettingsWindow.xaml.cs
@@ -1,0 +1,53 @@
+using System.IO;
+using System.Windows;
+using Microsoft.Win32;
+using Chessapp.Core;
+
+namespace Gui
+{
+    public partial class SettingsWindow : Window
+    {
+        public SettingsWindow()
+        {
+            InitializeComponent();
+            var cfg = ConfigService.LoadAppSettings();
+            TxtEnginePath.Text = cfg.EnginePath;
+            TxtDepth.Text = cfg.Depth.ToString();
+        }
+
+        private void Browse_Click(object sender, RoutedEventArgs e)
+        {
+            var ofd = new OpenFileDialog { Filter = "Engine (*.exe)|*.exe" };
+            if (ofd.ShowDialog() == true)
+            {
+                TxtEnginePath.Text = ofd.FileName;
+            }
+        }
+
+        private void Ok_Click(object sender, RoutedEventArgs e)
+        {
+            if (!File.Exists(TxtEnginePath.Text))
+            {
+                MessageBox.Show("Engine file not found.");
+                return;
+            }
+            if (!int.TryParse(TxtDepth.Text, out var depth) || depth <= 0)
+            {
+                MessageBox.Show("Depth must be a positive number.");
+                return;
+            }
+            var cfg = ConfigService.LoadAppSettings();
+            cfg.EnginePath = TxtEnginePath.Text;
+            cfg.Depth = depth;
+            ConfigService.SaveAppSettings(cfg);
+            DialogResult = true;
+            Close();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow setting engine path and analysis depth through new settings dialog
- persist chosen values in `appsettings.json`
- use configured depth when running analysis

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b22f6b520c8325a274c8e2d12d9b07