### PR TITLE
docs: add pre-release guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,39 +10,34 @@ ChessApp is a Windows (.NET 8 WPF) GUI that drives an external UCI engine such a
 - [Visual Studio 2022](https://visualstudio.microsoft.com/)
 - Optional UCI engine such as [`stockfish.exe`](https://stockfishchess.org/)
 
-codex/update-readme-quickstart-and-packaging-sections
 ### Run
 1. Clone the repo:
-
-1. Optionally place the engine at `Engines/stockfish.exe` with:
-
-   ```powershell
-   pwsh Scripts/prepare-engine.ps1 -Path C:\path\to\stockfish.exe
-   ```
-
-   or edit `Data/appsettings.json` to set `AppSettings.EnginePath`.
-2. Build the GUI:
- main
-
    ```powershell
    git clone <repo-url>
    cd ChessApp
    ```
-   Open `ChessApp.sln` in Visual Studio 2022.
-2. Configure the engine path: place the engine at `Engines/stockfish.exe` **or** edit `Data/appsettings.json` and set `AppSettings.EnginePath`.
-3. Set **Gui** as the startup project and run (F5).
+
+2. Optionally place the engine at `Engines/stockfish.exe`:
+   ```powershell
+   pwsh Scripts/prepare-engine.ps1 -Path C:\path\to\stockfish.exe
+   ```
+   or edit `Data/appsettings.json` and set `AppSettings.EnginePath`.
+
+3. Open `ChessApp.sln` in Visual Studio 2022.
+
+4. Set **Gui** as the startup project and run (F5).
 
 See [BUILD.md](docs/BUILD.md) for detailed instructions and [PROFILES.md](docs/PROFILES.md) for profile definitions.
 
 ## Packaging
 
-Run the PowerShell script to produce an MSIX package:
+Run the PowerShell script to stage an unsigned MSIX:
 
 ```powershell
-Scripts/build-msix.ps1
+pwsh Scripts/release-pack.ps1
 ```
 
-The packaged artifacts are written to the `artifacts` folder.
+Artifacts are written to `Artifacts/release`. Placeholder logos are generated; replace them with real artwork before a stable release.
 
 ## Troubleshooting
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,17 +1,16 @@
-# RELEASING
+# Releasing
 
-## Versionare
-- SemVer: MAJOR.MINOR.PATCH
+Steps to cut a pre-release build.
 
-## Checklist
-- [ ] CI verde pe `main`
-- [ ] Actualizează `CHANGELOG.md`
-- [ ] Etichetează versiunea `vX.Y.Z`
-- [ ] Build Release + MSIX
-- [ ] Atașează artefactele
-
-## Comenzi utile
-```bash
-git tag v0.1.0
-git push origin v0.1.0
-```
+1. Choose the next semantic version and create a tag:
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+2. GitHub Actions builds the project and publishes an unsigned MSIX artifact.
+3. Download the MSIX from the workflow run.
+4. On Windows, enable Developer Mode and install the package manually:
+   ```powershell
+   Add-AppxPackage .\ChessApp.msix
+   ```
+   The package is unsigned and intended only for testing.


### PR DESCRIPTION
## Summary
- add pre-release instructions for tagging and sideloading unsigned MSIX
- tidy README quickstart and packaging note about placeholder logos

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b22f7229548325a7236d3858ec9453