### PR TITLE
Clean up MainWindow and engine move handling

### DIFF
--- a/Core/GameController.cs
+++ b/Core/GameController.cs
@@ -19,13 +19,11 @@ public class GameController
     // Very small move list so the GUI can build a UCI "position" command.
     private readonly List<string> _moves = new();
 
-/add-method-to-apply-engine-move
     /// <summary>Raised whenever an engine move is applied.</summary>
     public event Action<string>? EngineMoveApplied;
 
     public GameController(ILogger<GameController>? logger = null)
         => _logger = logger ?? Logging.Factory.CreateLogger<GameController>();
- main
 
     /// <summary>Resets to the initial chess position.</summary>
     public void NewGame()
@@ -73,21 +71,24 @@ public class GameController
     /// <summary>
     /// Applies an engine move in UCI form. Uses the same validation as user
     /// moves and updates the internal move list. Raises <see
-    /// cref="EngineMoveApplied"/> when successful.
+    /// cref="EngineMoveApplied"/> when successful. Returns true if the move
+    /// was applied.
     /// </summary>
-    public void ApplyEngineMove(string uci)
+    public bool ApplyEngineMove(string uci)
     {
         if (TryApplyUserMove(uci))
         {
             EngineMoveApplied?.Invoke(uci.Trim());
+            return true;
         }
+        return false;
     }
 
     /// <summary>
     /// Overload for engine move using separate components (from, to,
     /// promotion).
     /// </summary>
-    public void ApplyEngineMove(object from, object to, object? promotion = null)
+    public bool ApplyEngineMove(object from, object to, object? promotion = null)
         => ApplyEngineMove(BuildUci(from, to, promotion));
 
     // Helpers

--- a/Gui/InsightsView.xaml.cs
+++ b/Gui/InsightsView.xaml.cs
@@ -1,7 +1,7 @@
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using Chessapp.Core;
+using Core;
 
 namespace Gui
 {

--- a/Gui/MainWindow.xaml
+++ b/Gui/MainWindow.xaml
@@ -24,7 +24,7 @@
         </StackPanel>
         <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
           <Button Name="BtnStop" Content="Stop" Width="120" Margin="0,0,8,0" Click="BtnStop_Click"/>
-          <Button Name="BtnLoadEngine" Content="Engine..." Width="120" Click="BtnLoadEngine_Click"/>
+          <Button Name="BtnSettings" Content="Settings..." Width="120" Click="BtnSettings_Click"/>
         </StackPanel>
         <TextBlock Name="TxtPv" Margin="0,0,0,8" TextWrapping="Wrap"/>
         <TabControl Height="420" Margin="0,8,0,0">
@@ -36,37 +36,15 @@
           </TabItem>
         </TabControl>
       </StackPanel>
-/add-engine-selection-modal-to-settings-ui
-      <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-        <Button Name="BtnStop" Content="Stop" Width="120" Margin="0,0,8,0" Click="BtnStop_Click"/>
-        <Button Name="BtnSettings" Content="Settings..." Width="120" Click="BtnSettings_Click"/>
-      </StackPanel>
-      <TextBlock Name="TxtPv" Margin="0,0,0,8" TextWrapping="Wrap"/>
-      <TabControl Height="420" Margin="0,8,0,0">
-        <TabItem Header="Info">
-          <TextBox Name="TxtInfo" IsReadOnly="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"/>
-        </TabItem>
-        <TabItem Header="Insights">
-          <local:InsightsView x:Name="InsightsPanel"/>
-        </TabItem>
-      </TabControl>
-    </StackPanel>
 
-codex/bind-analysis-summary-to-board-header
-    <Grid Grid.Column="1" Margin="8">
-      <Grid.RowDefinitions>
-        <RowDefinition Height="Auto"/>
-        <RowDefinition Height="*"/>
-      </Grid.RowDefinitions>
-      <TextBlock Text="{Binding AnalysisHeader}" Margin="0,0,0,8" FontWeight="Bold"/>
-      <controls:BoardControl x:Name="Board" Grid.Row="1"/>
-    </Grid>
-  </Grid>
-
- main
-
-      <controls:BoardControl x:Name="Board" Grid.Column="1" Margin="8"/>
+      <Grid Grid.Column="1" Margin="8">
+        <Grid.RowDefinitions>
+          <RowDefinition Height="Auto"/>
+          <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <TextBlock Text="{Binding AnalysisHeader}" Margin="0,0,0,8" FontWeight="Bold"/>
+        <controls:BoardControl x:Name="Board" Grid.Row="1"/>
+      </Grid>
     </Grid>
   </DockPanel>
-main
 </Window>

--- a/Gui/MainWindow.xaml.cs
+++ b/Gui/MainWindow.xaml.cs
@@ -3,14 +3,9 @@ using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
-/add-engine-selection-modal-to-settings-ui
-
-using System.ComponentModel;
-using System.Text;
-using Microsoft.Win32;
-main
 using Chessapp.Core;
 using Chessapp.Interop;
 
@@ -25,7 +20,6 @@ namespace Gui
         private bool _insightsEnabled = true;
         private string _enginePath = "Engines/stockfish.exe";
         private bool _analyzing = false;
- codex/bind-analysis-summary-to-board-header
         private string _analysisHeader = "Engine idle";
 
         public event PropertyChangedEventHandler? PropertyChanged;
@@ -38,10 +32,10 @@ namespace Gui
                 if (_analysisHeader == value) return;
                 _analysisHeader = value;
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AnalysisHeader)));
+            }
+        }
 
         private readonly StringBuilder _engineLog = new StringBuilder();
-
-        public event PropertyChangedEventHandler? PropertyChanged;
 
         public string EngineLog => _engineLog.ToString();
 
@@ -49,7 +43,6 @@ namespace Gui
         {
             _engineLog.AppendLine(line);
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(EngineLog)));
- main
         }
 
         public MainWindow()
@@ -88,7 +81,6 @@ namespace Gui
             TxtInfo.ScrollToEnd();
 
             var upd = UciParser.TryParseInfo(line);
-codex/bind-analysis-summary-to-board-header
             if (upd != null && !string.IsNullOrWhiteSpace(upd.Pv) && line.Contains(" score "))
             {
                 var moves = upd.Pv.Split(' ', StringSplitOptions.RemoveEmptyEntries).Take(4);
@@ -97,12 +89,13 @@ codex/bind-analysis-summary-to-board-header
                     ? $"M{upd.ScoreCp}"
                     : (upd.ScoreCp / 100.0).ToString("0.00", CultureInfo.InvariantCulture);
                 AnalysisHeader = $"{upd.Depth} | {eval} | {pv}";
+            }
 
             if (upd != null && !string.IsNullOrWhiteSpace(upd.Pv))
             {
                 var score = upd.ScoreMate ? $"mate {upd.ScoreCp}" : $"cp {upd.ScoreCp}";
                 AppendEngineLog($"d{upd.Depth} {score} {upd.Pv}");
- main
+
                 if (_insightsEnabled)
                 {
                     int? cp = upd.ScoreMate ? null : upd.ScoreCp;
@@ -170,18 +163,18 @@ codex/bind-analysis-summary-to-board-header
             }
         }
 
-        private async Task OnBestMove(string bestmove)
+        private Task OnBestMove(string bestmove)
         {
-            if (_analyzing) return;
-            if (_game.ApplyEngineMove(bestmove))
-            {
-                Board.SetPosition(_game.Fen);
-            }
-            else
+            if (_analyzing) return Task.CompletedTask;
+            if (!_game.ApplyEngineMove(bestmove))
             {
                 AppendInfo($"Engine sent impossible bestmove: {bestmove}");
+                return Task.CompletedTask;
             }
+
+            Board.SetPosition(_game.Fen);
             AnalysisHeader = "Engine idle";
+            return Task.CompletedTask;
         }
 
         private async void BtnAnalyze_Click(object sender, RoutedEventArgs e)
@@ -193,15 +186,10 @@ codex/bind-analysis-summary-to-board-header
             await SendCommandAsync("isready");
             await _engine.ExpectAsync("readyok", TimeSpan.FromSeconds(3));
             var cfg = ConfigService.LoadAppSettings();
-/add-engine-selection-modal-to-settings-ui
-            await _engine.SendAsync(_game.ToUciPositionCommand());
-            await _engine.SendAsync("setoption name MultiPV value 3");
-            await _engine.SendAsync($"go depth {cfg.Depth}");
 
             await SendCommandAsync(_game.ToUciPositionCommand());
             await SendCommandAsync("setoption name MultiPV value 3");
-            await SendCommandAsync("go infinite");
- main
+            await SendCommandAsync($"go depth {cfg.Depth}");
         }
 
         private async void BtnStop_Click(object sender, RoutedEventArgs e)

--- a/Gui/MainWindow.xaml.cs
+++ b/Gui/MainWindow.xaml.cs
@@ -6,8 +6,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
-using Chessapp.Core;
-using Chessapp.Interop;
+using Core;
+using Interop;
 
 namespace Gui
 {

--- a/Gui/SettingsWindow.xaml.cs
+++ b/Gui/SettingsWindow.xaml.cs
@@ -1,7 +1,7 @@
 using System.IO;
 using System.Windows;
 using Microsoft.Win32;
-using Chessapp.Core;
+using Core;
 
 namespace Gui
 {

--- a/tests/Core.Tests/GameControllerTests.cs
+++ b/tests/Core.Tests/GameControllerTests.cs
@@ -36,7 +36,8 @@ public class GameControllerTests
     {
         var gc = new GameController();
         gc.NewGame();
-        gc.ApplyEngineMove("g8f6");
+        bool applied = gc.ApplyEngineMove("g8f6");
+        Assert.True(applied);
         Assert.Equal("position startpos moves g8f6", gc.ToUciPositionCommand());
     }
 
@@ -47,7 +48,8 @@ public class GameControllerTests
         gc.NewGame();
         string? notified = null;
         gc.EngineMoveApplied += m => notified = m;
-        gc.ApplyEngineMove("g8f6");
+        bool applied = gc.ApplyEngineMove("g8f6");
+        Assert.True(applied);
         Assert.Equal("g8f6", notified);
     }
 }


### PR DESCRIPTION
## Summary
- strip placeholder markers and deduplicate usings
- fix AnalysisHeader and engine log handling
- rely on GameController.ApplyEngineMove boolean return and streamline analyze commands

## Testing
- `apt-get update` *(fails: The repository is not signed)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b234ea34ac8325ae01f2561723e4f1